### PR TITLE
Support detection and removal of Office for Mac 2021 consumer licenses

### DIFF
--- a/Unlicense
+++ b/Unlicense
@@ -199,7 +199,7 @@ function ForceQuitApps {
 
 # Checks to see if a volume license file is present
 function DetectPerpetualLicense {
-	if [ -f "$PERPETUALLICENSE" ] || [ -e "$VNEXTPERPETUALLICENSEPATH" ]; then
+	if [[ -f "$PERPETUALLICENSE" ] || [ -e "$VNEXTPERPETUALLICENSEPATH" ]]; then
 		echo "1"
 	else
 		echo "0"


### PR DESCRIPTION
Office for Mac 2021 consumer licenses are stored in a new location. Update the license removal tool to detect the presence of that location and clear it up.